### PR TITLE
Add action to publish extension to Open VSX

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,3 +14,6 @@ jobs:
           args: "publish -p $PUBLISHER_TOKEN"
         env:
           PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
+
+      - name: Publish to Open VSX
+        run: npx ovsx publish -p ${{ secrets.OPENVSX_TOKEN }}


### PR DESCRIPTION
This change will close issue #4 by adding publishing to Open VSX.
